### PR TITLE
rustup - fix mutable slice syntax.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ impl Sha1 {
     /// Shortcut for getting `output` into a new vector.
     pub fn digest(&self) -> Vec<u8> {
         let mut buf = Vec::from_elem(20, 0u8);
-        self.output(buf[mut]);
+        self.output(buf.as_mut_slice());
         buf
     }
 


### PR DESCRIPTION
Following https://github.com/rust-lang/rust/commit/4e2afb0052618ca3d758fffd0cf50559be774391.
