### PR TITLE
Adopt to latest Rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,18 @@
 #![experimental]
 
 use std::io::{MemWriter, BufWriter};
+use std::iter::repeat;
 
 
 /// Represents a Sha1 hash object in memory.
-#[deriving(Clone)]
+#[derive(Clone)]
 pub struct Sha1 {
-    state: [u32, ..5],
+    state: [u32; 5],
     data: Vec<u8>,
     len: u64,
 }
 
-const DEFAULT_STATE : [u32, ..5] =
+const DEFAULT_STATE : [u32; 5] =
     [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0];
 
 
@@ -55,12 +56,12 @@ impl Sha1 {
     fn process_block(&mut self, block: &[u8]) {
         assert_eq!(block.len(), 64);
 
-        let mut words = [0u32, ..80];
+        let mut words = [0u32; 80];
         for (i, chunk) in block.chunks(4).enumerate() {
             words[i] = (chunk[3] as u32) |
-                       (chunk[2] as u32 << 8) |
-                       (chunk[1] as u32 << 16) |
-                       (chunk[0] as u32 << 24);
+                       ((chunk[2] as u32) << 8) |
+                       ((chunk[1] as u32) << 16) |
+                       ((chunk[0] as u32) << 24);
         }
 
         let ff = |b: u32, c: u32, d: u32| d ^ (b & (c ^ d));
@@ -146,7 +147,7 @@ impl Sha1 {
         w.write(self.data[]);
         w.write_u8(0x80 as u8);
         let padding = (((56 - self.len as int - 1) % 64) + 64) % 64;
-        w.write(Vec::from_elem(padding as uint, 0u8)[]);
+        w.write(repeat(0u8).take(padding as uint).collect::<Vec<_>>()[]);
         w.write_be_u64(self.len * 8);
         for chunk in w.get_ref()[].chunks(64) {
             m.process_block(chunk);
@@ -160,8 +161,8 @@ impl Sha1 {
 
     /// Shortcut for getting `output` into a new vector.
     pub fn digest(&self) -> Vec<u8> {
-        let mut buf = Vec::from_elem(20, 0u8);
-        self.output(buf[mut]);
+        let mut buf = repeat(0u8).take(20).collect::<Vec<_>>();
+        self.output(buf.as_mut_slice());
         buf
     }
 


### PR DESCRIPTION
- deriving becomes derive
- New syntax for fixed-length array
- Wrap expression in parentheses before shifting
- Replace deprecated methods with iteration
- Pass buffer as mutable
