### PR TITLE
Update to latest Rust + fix invalid message size calculation in case of multipart message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "sha1"
-version = "0.0.5"
-authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
+name = "sha1-hasher"
+version = "0.0.1"
+authors = ["Armin Ronacher <armin.ronacher@active-4.com>", "Konstantin Stepanov <me@kstep.me>"]
 keywords = ["sha1"]
-description = "Minimal implementation of SHA1 for Rust."
+description = "Minimal implementation of SHA1 for Rust (with fixes and Hasher trait implementation)"
 license = "BSD-3-Clause"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ impl Sha1 {
 #[cfg(test)]
 mod tests {
     use test::Bencher;
-    use super::Sha1;
+    use super::{Sha1, to_hex};
 
     #[test]
     fn test_simple() {
@@ -203,6 +203,21 @@ mod tests {
             assert_eq!(hh.len(), h.len());
             assert_eq!(hh[], *h);
         }
+    }
+
+    #[test]
+    fn test_dirty_run() {
+        let mut m = Sha1::new();
+
+        m.update(b"123");
+        let out1 = m.digest();
+
+        m.update(b"123");
+        let out2 = m.digest();
+
+        assert!(out1[] != out2[]);
+        assert_eq!(to_hex(out1[])[], "40bd001563085fc35165329ea1ff5c5ecbdbbeef");
+        assert_eq!(to_hex(out2[])[], "601f1889667efaebb33b8c12572835da3f027f78");
     }
 
     #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@
 
 #![experimental]
 
-use std::io::{MemWriter, BufWriter};
-
+use std::io::BufWriter;
 
 /// Represents a Sha1 hash object in memory.
 #[derive(Clone)]
@@ -142,7 +141,7 @@ impl Sha1 {
             len: 0,
         };
 
-        let mut w = MemWriter::new();
+        let mut w = Vec::<u8>::new();
         w.write(self.data[]);
         w.write_u8(0x80 as u8);
         let padding = (((56 - self.len as int - 1) % 64) + 64) % 64;
@@ -150,7 +149,7 @@ impl Sha1 {
             w.write_u8(0u8);
         }
         w.write_be_u64(self.len * 8);
-        for chunk in w.get_ref()[].chunks(64) {
+        for chunk in w[].chunks(64) {
             m.process_block(chunk);
         }
 


### PR DESCRIPTION
Beside the obvious update to latest Rust, I also added some benchmark test and discovered a nasty bug, which appears if message is feed in parts (i.e. `update()` is called several times).

The problem is, you add up message length in chunks, no matter if the chunk is processed immediately (64-byte chunk) or put back for later processing (tail chunks with size less than 64 bytes), but on the next `update()` call you add the same tail length again, as a part of processed chunk, plus more tail length, which will be summed up _again_ on yet another `update()` call, etc, etc...

So you skew `self.len` size counter further from real message size on each `update()` call. The fix is to add up size only when you process the chunk, and then add tail length on `output()`, which I did.

Also I rewrote padding calculation a little to make math behind it more obvious.
