### PR TITLE
Delete #![unstable]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 //! # }
 //! ```
 
-#![unstable]
-
 extern crate byteorder;
 use std::io::{Cursor,Write};
 use std::io::BufWriter;


### PR DESCRIPTION
stability attributes may not be used outside of the standard library
