### PR TITLE
Make library #![no_std] compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ description = "Minimal implementation of SHA1 for Rust."
 license = "BSD-3-Clause"
 repository = "https://github.com/mitsuhiko/rust-sha1"
 
-[dependencies]
-byteorder = "*"
+[dev-dependencies]
+openssl = "0.7"
+rand = "0.3"


### PR DESCRIPTION
This commit removes allocations/vectors/etc to make this library `#![no_std]`
compatible, and also adds an extra "hard test" which throw a bunch of random
data at both OpenSSL (a reference implementation) and this crate to ensure that
they always get the same results.
