### PR TITLE
Use more accurate variable name for the loop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,8 +229,8 @@ impl Clone for Blocks {
 
 impl fmt::Display for Digest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for byte in self.data.state.iter() {
-            try!(write!(f, "{:08x}", byte));
+        for i in self.data.state.iter() {
+            try!(write!(f, "{:08x}", i));
         }
         Ok(())
     }


### PR DESCRIPTION
Minor naming fix since it's iterating over a u32 array.
