### PR TITLE
Update openssl dependency from 0.7 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ license = "BSD-3-Clause"
 repository = "https://github.com/mitsuhiko/rust-sha1"
 
 [dev-dependencies]
-openssl = "0.7"
+openssl = "0.9"
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,8 @@ mod tests {
         let mut bytes = [0; 512];
 
         for _ in 0..20 {
-            let ty = openssl::crypto::hash::Type::SHA1;
-            let mut r = openssl::crypto::hash::Hasher::new(ty);
+            let ty = openssl::hash::MessageDigest::sha1();
+            let mut r = openssl::hash::Hasher::new(ty).unwrap();
             m.reset();
             for _ in 0..50 {
                 let len = rng.gen::<usize>() % bytes.len();
@@ -345,7 +345,7 @@ mod tests {
                 m.update(&bytes[..len]);
                 r.write(&bytes[..len]).unwrap();
             }
-            assert_eq!(r.finish(), m.digest().bytes());
+            assert_eq!(r.finish().unwrap(), m.digest().bytes());
         }
     }
 }


### PR DESCRIPTION
Updates openssl from 0.7 to 0.9

This is a nice update for mac users, since homebrew now no longer installs openssl in a way that rust-openssl 0.7 recognizes, but 0.9 does find the right version without tweaking.