### PR TITLE
Add `set -e` to upload-docs to stop on errors

### DIFF
--- a/upload-docs.sh
+++ b/upload-docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Make a new repo for the gh-pages branch
 rm -rf .gh-pages
 mkdir .gh-pages


### PR DESCRIPTION
I just noticed this while poking around. `set -e` will cause the whole script to fail if any step fails, which is probably good in this case. Keep in mind that I didn't actually run the script, so you might want to test that this works as expected.