### PR TITLE
Use a Justfile instead of a Makefile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,5 +15,3 @@ docs: build
 
 upload-docs: docs
 	@./upload-docs.sh
-
-.PHONY: build test docs upload-docs


### PR DESCRIPTION
This is a pretty silly PR, but I thought you might find it interesting.

I wrote a program called `just` which is basically just `make` for running commands.

Some advantages over make:

* It can be called in any subdirectory. It will `cd` up until it finds a file called `justfile` or `Justfile` and run commands from any directory.

* It gives very helpful error messages when you mess up the syntax of the justfile, as opposed to the super cryptic error messages that make gives

* It is written in rust, so you can `cargo install just` and be done with it. It relies on `sh` from the host system, but that's it.

* It supports a lot of options, like recipes with parameters, etc, documented in the readme.

* No `.PHONY` recipe necessary XD

Feel free to close if you're not interested.