### PR TITLE
Support the Write trait when std feature is enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,16 @@ impl Default for Sha1 {
     }
 }
 
+#[cfg(feature="std")]
+impl std::io::Write for Sha1 {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.update(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+}
+
 impl Sha1 {
     /// Creates an fresh sha1 hash object.
     ///
@@ -729,6 +739,16 @@ mod tests {
         assert!("asdfasdf".parse::<Digest>().is_err());
         assert_eq!("asdfasdf".parse::<Digest>()
             .map_err(|x| x.description().to_string()).unwrap_err(), "not a valid sha1 hash");
+    }
+
+    #[test]
+    #[cfg(feature="std")]
+    fn test_write() {
+        let mut data: &[u8] = &[b'x'; 65535];
+        let mut writer = Sha1::new();
+        std::io::copy(&mut data, &mut writer).unwrap();
+        assert_eq!(writer.digest().to_string(),
+                   "61fd9f5ce720067d6801bb97049da9fdb4837531");
     }
 }
 


### PR DESCRIPTION
Many other hash function crates (like [`md5`](https://docs.rs/md5/0.3.7/md5/struct.Context.html#impl-Write) or [`crypto-hash`](https://docs.rs/crypto-hash/0.3.1/crypto_hash/struct.Hasher.html#impl-Write)) have their hash objects support the `std::io::Write` trait, with any `write` calls updating the hash with the given data.  This can be very handy, allowing things like using `std::io::copy()` to easily hash the entire contents of an artibrary `Read` type without having to read all the data into memory at once.

I recently found myself wishing for this capability in the `sha1` crate too, so this PR adds a `Write` impl for the `Sha1` type (only when the `"std"` feature is enabled, of course).