### PR TITLE
guard hexdigest() doctest by cfg(feature=std)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //! ```
 //! extern crate sha1;
 //! # fn main() {
+//! #[cfg(feature="std")]
 //! assert_eq!(sha1::Sha1::from("Hello World!").hexdigest(),
 //!            "2ef7bde608ce5404e97d5f042f95f89f1c232871");
 //! # }


### PR DESCRIPTION
Fixes: https://github.com/mitsuhiko/rust-sha1/issues/34