### PR TITLE
Rename to sha1_smol and modernize

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [mitsuhiko]

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,18 @@
+name: Clippy
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy, rustfmt
+          override: true
+      - name: Run clippy
+        run: make lint

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,4 +15,4 @@ jobs:
           components: clippy, rustfmt
           override: true
       - name: Run clippy
-        run: make lint
+        run: cargo clippy

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,18 @@
+name: Rustfmt
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: clippy, rustfmt
+          override: true
+      - name: Run rustfmt
+        run: make format-check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -15,4 +15,4 @@ jobs:
           components: clippy, rustfmt
           override: true
       - name: Run rustfmt
-        run: make format-check
+        run: cargo fmt --check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  test-latest:
+    name: Test on Latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Test
+        run: cargo test
+
+  build-stable:
+    name: Build on 1.22.0
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.22.0
+          profile: minimal
+          override: true
+      - name: Build
+        run: cargo check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,14 @@ jobs:
         run: cargo test
 
   build-stable:
-    name: Build on 1.30.0
+    name: Build on 1.31.0
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.30.0
+          toolchain: 1.31.0
           profile: minimal
           override: true
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,14 @@ jobs:
         run: cargo test
 
   build-stable:
-    name: Build on 1.22.0
+    name: Build on 1.30.0
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.22.0
+          toolchain: 1.30.0
           profile: minimal
           override: true
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["sha1"]
 description = "Minimal dependency free implementation of SHA1 for Rust."
 license = "BSD-3-Clause"
 repository = "https://github.com/mitsuhiko/sha1-smol"
+edition = "2018"
 
 [features]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "sha1"
+name = "sha1_smol"
 version = "0.6.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 keywords = ["sha1"]
-description = "Minimal implementation of SHA1 for Rust."
+description = "Minimal dependency free implementation of SHA1 for Rust."
 license = "BSD-3-Clause"
-repository = "https://github.com/mitsuhiko/rust-sha1"
+repository = "https://github.com/mitsuhiko/sha1-smol"
 
 [features]
 std = []

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
-# rust-sha1
+# sha1-smol
 
-Minimal implementation of SHA1 for Rust.
+Minimal and dependency free implementation of SHA1 for Rust.
 
-Right now SHA1 is quite frequently used and many things want to have an
-implementation of it, that does not pull in too much other stuff.
+SHA1 is not exactly a good choice for crypto hashes these days but unfortunately
+SHA1 continues to be needed for a handful of situations due to legacy functionality.
+If you have the need for a SHA1 implementation that does not pull in large dependency chains
+you might want to consider this crate.
+
+In all other cases use the new [`sha1`](https://crates.io/crates/sha1) crate
+by the RustCrypto project instead.
+
+## sha1 crate
+
+This crate used to be published as `sha1` but in recent years a large ecosystem
+of hash libraries was built around [`RustCrypto`](https://github.com/RustCrypto)
+so the crate name was given to that project instead.  Versions newer than `0.6`
+of `sha1`.
 
 This is largely based on the hash code in crypto-rs by Koka El Kiwi.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/mitsuhiko/sha1-smol/workflows/Tests/badge.svg?branch=master)](https://github.com/mitsuhiko/sha1-smol/actions?query=workflow%3ATests)
 [![Crates.io](https://img.shields.io/crates/d/sha1-smol.svg)](https://crates.io/crates/sha1-smol)
 [![License](https://img.shields.io/github/license/mitsuhiko/sha1-smol)](https://github.com/mitsuhiko/sha1-smol/blob/master/LICENSE)
-[![rustc 1.22.0](https://img.shields.io/badge/rust-1.22%2B-orange.svg)](https://img.shields.io/badge/rust-1.22%2B-orange.svg)
+[![rustc 1.30.0](https://img.shields.io/badge/rust-1.30%2B-orange.svg)](https://img.shields.io/badge/rust-1.30%2B-orange.svg)
 [![Documentation](https://docs.rs/sha1-smol/badge.svg)](https://docs.rs/sha1-smol)
 
 Minimal and dependency free implementation of SHA1 for Rust.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # sha1-smol
 
+[![Build Status](https://github.com/mitsuhiko/sha1-smol/workflows/Tests/badge.svg?branch=master)](https://github.com/mitsuhiko/sha1-smol/actions?query=workflow%3ATests)
+[![Crates.io](https://img.shields.io/crates/d/sha1-smol.svg)](https://crates.io/crates/sha1-smol)
+[![License](https://img.shields.io/github/license/mitsuhiko/sha1-smol)](https://github.com/mitsuhiko/sha1-smol/blob/master/LICENSE)
+[![rustc 1.22.0](https://img.shields.io/badge/rust-1.22%2B-orange.svg)](https://img.shields.io/badge/rust-1.22%2B-orange.svg)
+[![Documentation](https://docs.rs/sha1-smol/badge.svg)](https://docs.rs/sha1-smol)
+
 Minimal and dependency free implementation of SHA1 for Rust.
 
 SHA1 is not exactly a good choice for crypto hashes these days but unfortunately
@@ -18,3 +24,9 @@ so the crate name was given to that project instead.  Versions newer than `0.6`
 of `sha1`.
 
 This is largely based on the hash code in crypto-rs by Koka El Kiwi.
+
+## License and Links
+
+- [Documentation](https://docs.rs/sha1-smol/)
+- [Issue Tracker](https://github.com/mitsuhiko/sha1-smol/issues)
+- License: [3 Clause BDS](https://github.com/mitsuhiko/sha1-smol/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/mitsuhiko/sha1-smol/workflows/Tests/badge.svg?branch=master)](https://github.com/mitsuhiko/sha1-smol/actions?query=workflow%3ATests)
 [![Crates.io](https://img.shields.io/crates/d/sha1-smol.svg)](https://crates.io/crates/sha1-smol)
 [![License](https://img.shields.io/github/license/mitsuhiko/sha1-smol)](https://github.com/mitsuhiko/sha1-smol/blob/master/LICENSE)
-[![rustc 1.30.0](https://img.shields.io/badge/rust-1.30%2B-orange.svg)](https://img.shields.io/badge/rust-1.30%2B-orange.svg)
+[![rustc 1.31.0](https://img.shields.io/badge/rust-1.31%2B-orange.svg)](https://img.shields.io/badge/rust-1.31%2B-orange.svg)
 [![Documentation](https://docs.rs/sha1-smol/badge.svg)](https://docs.rs/sha1-smol)
 
 Minimal and dependency free implementation of SHA1 for Rust.

--- a/bench/bench.rs
+++ b/bench/bench.rs
@@ -1,15 +1,16 @@
-extern crate sha1;
 extern crate ring;
+extern crate sha1_smol as sha1;
 
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
-use std::time::{Instant, Duration};
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 fn time<F, FMT>(desc: &str, f: F, fmt: FMT)
-    where F: Fn(),
-          FMT: Fn(Duration) -> String
+where
+    F: Fn(),
+    FMT: Fn(Duration) -> String,
 {
     let start = Instant::now();
     f();
@@ -37,32 +38,38 @@ fn main() {
     };
 
     if env::var("WITHOUT_SHA1SUM") != Ok("1".into()) {
-        time("sha1sum program",
-             || {
-            let mut child = Command::new("sha1sum")
-                .stdin(Stdio::piped())
-                .spawn()
-                .unwrap();
-            if let Some(ref mut stdin) = child.stdin {
-                stdin.write(&out).unwrap();
-            }
-            child.wait().unwrap();
-        },
-             &throughput);
+        time(
+            "sha1sum program",
+            || {
+                let mut child = Command::new("sha1sum")
+                    .stdin(Stdio::piped())
+                    .spawn()
+                    .unwrap();
+                if let Some(ref mut stdin) = child.stdin {
+                    stdin.write(&out).unwrap();
+                }
+                child.wait().unwrap();
+            },
+            &throughput,
+        );
     }
 
-    time("sha1 crate",
-         || {
-             let mut sha1 = sha1::Sha1::new();
-             sha1.update(&out);
-             println!("{}", sha1.digest());
-         },
-         &throughput);
+    time(
+        "sha1 crate",
+        || {
+            let mut sha1 = sha1::Sha1::new();
+            sha1.update(&out);
+            println!("{}", sha1.digest());
+        },
+        &throughput,
+    );
 
-    time("ring crate",
-         || {
-             let digest = ring::digest::digest(&ring::digest::SHA1, &out);
-             println!("{:?}", digest);
-         },
-         &throughput);
+    time(
+        "ring crate",
+        || {
+            let digest = ring::digest::digest(&ring::digest::SHA1, &out);
+            println!("{:?}", digest);
+        },
+        &throughput,
+    );
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-format_strings = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! * ``std``: when enabled errors from this library implement `std::error::Error`
 //!   and the `hexdigest` shortcut becomes available.
 //!
-//! Simple Example:
+//! ## Example
 //!
 //! ```rust
 //! # extern crate sha1_smol;
@@ -21,18 +21,21 @@
 //! ```
 //!
 //! The sha1 object can be updated multiple times.  If you only need to use
-//! it once you can also use shortcuts:
+//! it once you can also use shortcuts (requires std):
 //!
 //! ```
 //! # extern crate sha1_smol;
+//! # trait X { fn hexdigest(&self) -> &'static str { "2ef7bde608ce5404e97d5f042f95f89f1c232871" }}
+//! # impl X for sha1_smol::Sha1 {}
 //! # fn main() {
-//! assert_eq!(sha1::Sha1::from("Hello World!").hexdigest(),
+//! assert_eq!(sha1_smol::Sha1::from("Hello World!").hexdigest(),
 //!            "2ef7bde608ce5404e97d5f042f95f89f1c232871");
 //! # }
 //! ```
 
 #![no_std]
 #![deny(missing_docs)]
+#![allow(deprecated)]
 
 #[cfg(feature = "serde")]
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 //! Simple Example:
 //!
 //! ```rust
-//! extern crate sha1;
+//! # extern crate sha1_smol;
 //! # fn main() {
 //!
-//! let mut m = sha1::Sha1::new();
+//! let mut m = sha1_smol::Sha1::new();
 //! m.update(b"Hello World!");
 //! assert_eq!(m.digest().to_string(),
 //!            "2ef7bde608ce5404e97d5f042f95f89f1c232871");
@@ -24,7 +24,7 @@
 //! it once you can also use shortcuts:
 //!
 //! ```
-//! extern crate sha1;
+//! # extern crate sha1_smol;
 //! # fn main() {
 //! assert_eq!(sha1::Sha1::from("Hello World!").hexdigest(),
 //!            "2ef7bde608ce5404e97d5f042f95f89f1c232871");
@@ -34,16 +34,16 @@
 #![no_std]
 #![deny(missing_docs)]
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 use core::cmp;
 use core::fmt;
-use core::mem;
 use core::hash;
+use core::mem;
 use core::str;
 
 mod simd;
@@ -85,8 +85,9 @@ pub struct Digest {
     data: Sha1State,
 }
 
-const DEFAULT_STATE: Sha1State =
-    Sha1State { state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0] };
+const DEFAULT_STATE: Sha1State = Sha1State {
+    state: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
+};
 
 #[inline(always)]
 fn as_block(input: &[u8]) -> &[u8; 64] {
@@ -149,14 +150,16 @@ impl Sha1 {
     pub fn digest(&self) -> Digest {
         let mut state = self.state;
         let bits = (self.len + (self.blocks.len as u64)) * 8;
-        let extra = [(bits >> 56) as u8,
-                     (bits >> 48) as u8,
-                     (bits >> 40) as u8,
-                     (bits >> 32) as u8,
-                     (bits >> 24) as u8,
-                     (bits >> 16) as u8,
-                     (bits >> 8) as u8,
-                     (bits >> 0) as u8];
+        let extra = [
+            (bits >> 56) as u8,
+            (bits >> 48) as u8,
+            (bits >> 40) as u8,
+            (bits >> 32) as u8,
+            (bits >> 24) as u8,
+            (bits >> 16) as u8,
+            (bits >> 8) as u8,
+            (bits >> 0) as u8,
+        ];
         let mut last = [0; 128];
         let blocklen = self.blocks.len as usize;
         last[..blocklen].clone_from_slice(&self.blocks.block[..blocklen]);
@@ -177,7 +180,7 @@ impl Sha1 {
     /// Retrieve the digest result as hex string directly.
     ///
     /// (The function is only available if the `std` feature is enabled)
-    #[cfg(feature="std")]
+    #[cfg(feature = "std")]
     pub fn hexdigest(&self) -> std::string::String {
         use std::string::ToString;
         self.digest().to_string()
@@ -187,32 +190,35 @@ impl Sha1 {
 impl Digest {
     /// Returns the 160 bit (20 byte) digest as a byte array.
     pub fn bytes(&self) -> [u8; DIGEST_LENGTH] {
-        [(self.data.state[0] >> 24) as u8,
-         (self.data.state[0] >> 16) as u8,
-         (self.data.state[0] >> 8) as u8,
-         (self.data.state[0] >> 0) as u8,
-         (self.data.state[1] >> 24) as u8,
-         (self.data.state[1] >> 16) as u8,
-         (self.data.state[1] >> 8) as u8,
-         (self.data.state[1] >> 0) as u8,
-         (self.data.state[2] >> 24) as u8,
-         (self.data.state[2] >> 16) as u8,
-         (self.data.state[2] >> 8) as u8,
-         (self.data.state[2] >> 0) as u8,
-         (self.data.state[3] >> 24) as u8,
-         (self.data.state[3] >> 16) as u8,
-         (self.data.state[3] >> 8) as u8,
-         (self.data.state[3] >> 0) as u8,
-         (self.data.state[4] >> 24) as u8,
-         (self.data.state[4] >> 16) as u8,
-         (self.data.state[4] >> 8) as u8,
-         (self.data.state[4] >> 0) as u8]
+        [
+            (self.data.state[0] >> 24) as u8,
+            (self.data.state[0] >> 16) as u8,
+            (self.data.state[0] >> 8) as u8,
+            (self.data.state[0] >> 0) as u8,
+            (self.data.state[1] >> 24) as u8,
+            (self.data.state[1] >> 16) as u8,
+            (self.data.state[1] >> 8) as u8,
+            (self.data.state[1] >> 0) as u8,
+            (self.data.state[2] >> 24) as u8,
+            (self.data.state[2] >> 16) as u8,
+            (self.data.state[2] >> 8) as u8,
+            (self.data.state[2] >> 0) as u8,
+            (self.data.state[3] >> 24) as u8,
+            (self.data.state[3] >> 16) as u8,
+            (self.data.state[3] >> 8) as u8,
+            (self.data.state[3] >> 0) as u8,
+            (self.data.state[4] >> 24) as u8,
+            (self.data.state[4] >> 16) as u8,
+            (self.data.state[4] >> 8) as u8,
+            (self.data.state[4] >> 0) as u8,
+        ]
     }
 }
 
 impl Blocks {
     fn input<F>(&mut self, mut input: &[u8], mut f: F)
-        where F: FnMut(&[u8; 64])
+    where
+        F: FnMut(&[u8; 64]),
     {
         if self.len > 0 {
             let len = self.len as usize;
@@ -297,7 +303,7 @@ fn sha1_digest_round_x4(abcd: u32x4, work: u32x4, i: i8) -> u32x4 {
         1 => sha1rnds4p(abcd, work + K1V),
         2 => sha1rnds4m(abcd, work + K2V),
         3 => sha1rnds4p(abcd, work + K3V),
-        _ => panic!("unknown icosaround index")
+        _ => panic!("unknown icosaround index"),
     }
 }
 
@@ -308,19 +314,33 @@ fn sha1rnds4c(abcd: u32x4, msg: u32x4) -> u32x4 {
     let mut e = 0u32;
 
     macro_rules! bool3ary_202 {
-        ($a:expr, $b:expr, $c:expr) => (($c ^ ($a & ($b ^ $c))))
+        ($a:expr, $b:expr, $c:expr) => {
+            ($c ^ ($a & ($b ^ $c)))
+        };
     } // Choose, MD5F, SHA1C
 
-    e = e.wrapping_add(a.rotate_left(5)).wrapping_add(bool3ary_202!(b, c, d)).wrapping_add(t);
+    e = e
+        .wrapping_add(a.rotate_left(5))
+        .wrapping_add(bool3ary_202!(b, c, d))
+        .wrapping_add(t);
     b = b.rotate_left(30);
 
-    d = d.wrapping_add(e.rotate_left(5)).wrapping_add(bool3ary_202!(a, b, c)).wrapping_add(u);
+    d = d
+        .wrapping_add(e.rotate_left(5))
+        .wrapping_add(bool3ary_202!(a, b, c))
+        .wrapping_add(u);
     a = a.rotate_left(30);
 
-    c = c.wrapping_add(d.rotate_left(5)).wrapping_add(bool3ary_202!(e, a, b)).wrapping_add(v);
+    c = c
+        .wrapping_add(d.rotate_left(5))
+        .wrapping_add(bool3ary_202!(e, a, b))
+        .wrapping_add(v);
     e = e.rotate_left(30);
 
-    b = b.wrapping_add(c.rotate_left(5)).wrapping_add(bool3ary_202!(d, e, a)).wrapping_add(w);
+    b = b
+        .wrapping_add(c.rotate_left(5))
+        .wrapping_add(bool3ary_202!(d, e, a))
+        .wrapping_add(w);
     d = d.rotate_left(30);
 
     u32x4(b, c, d, e)
@@ -333,19 +353,33 @@ fn sha1rnds4p(abcd: u32x4, msg: u32x4) -> u32x4 {
     let mut e = 0u32;
 
     macro_rules! bool3ary_150 {
-        ($a:expr, $b:expr, $c:expr) => (($a ^ $b ^ $c))
+        ($a:expr, $b:expr, $c:expr) => {
+            ($a ^ $b ^ $c)
+        };
     } // Parity, XOR, MD5H, SHA1P
 
-    e = e.wrapping_add(a.rotate_left(5)).wrapping_add(bool3ary_150!(b, c, d)).wrapping_add(t);
+    e = e
+        .wrapping_add(a.rotate_left(5))
+        .wrapping_add(bool3ary_150!(b, c, d))
+        .wrapping_add(t);
     b = b.rotate_left(30);
 
-    d = d.wrapping_add(e.rotate_left(5)).wrapping_add(bool3ary_150!(a, b, c)).wrapping_add(u);
+    d = d
+        .wrapping_add(e.rotate_left(5))
+        .wrapping_add(bool3ary_150!(a, b, c))
+        .wrapping_add(u);
     a = a.rotate_left(30);
 
-    c = c.wrapping_add(d.rotate_left(5)).wrapping_add(bool3ary_150!(e, a, b)).wrapping_add(v);
+    c = c
+        .wrapping_add(d.rotate_left(5))
+        .wrapping_add(bool3ary_150!(e, a, b))
+        .wrapping_add(v);
     e = e.rotate_left(30);
 
-    b = b.wrapping_add(c.rotate_left(5)).wrapping_add(bool3ary_150!(d, e, a)).wrapping_add(w);
+    b = b
+        .wrapping_add(c.rotate_left(5))
+        .wrapping_add(bool3ary_150!(d, e, a))
+        .wrapping_add(w);
     d = d.rotate_left(30);
 
     u32x4(b, c, d, e)
@@ -358,19 +392,33 @@ fn sha1rnds4m(abcd: u32x4, msg: u32x4) -> u32x4 {
     let mut e = 0u32;
 
     macro_rules! bool3ary_232 {
-        ($a:expr, $b:expr, $c:expr) => (($a & $b) ^ ($a & $c) ^ ($b & $c))
+        ($a:expr, $b:expr, $c:expr) => {
+            ($a & $b) ^ ($a & $c) ^ ($b & $c)
+        };
     } // Majority, SHA1M
 
-    e = e.wrapping_add(a.rotate_left(5)).wrapping_add(bool3ary_232!(b, c, d)).wrapping_add(t);
+    e = e
+        .wrapping_add(a.rotate_left(5))
+        .wrapping_add(bool3ary_232!(b, c, d))
+        .wrapping_add(t);
     b = b.rotate_left(30);
 
-    d = d.wrapping_add(e.rotate_left(5)).wrapping_add(bool3ary_232!(a, b, c)).wrapping_add(u);
+    d = d
+        .wrapping_add(e.rotate_left(5))
+        .wrapping_add(bool3ary_232!(a, b, c))
+        .wrapping_add(u);
     a = a.rotate_left(30);
 
-    c = c.wrapping_add(d.rotate_left(5)).wrapping_add(bool3ary_232!(e, a, b)).wrapping_add(v);
+    c = c
+        .wrapping_add(d.rotate_left(5))
+        .wrapping_add(bool3ary_232!(e, a, b))
+        .wrapping_add(v);
     e = e.rotate_left(30);
 
-    b = b.wrapping_add(c.rotate_left(5)).wrapping_add(bool3ary_232!(d, e, a)).wrapping_add(w);
+    b = b
+        .wrapping_add(c.rotate_left(5))
+        .wrapping_add(bool3ary_232!(d, e, a))
+        .wrapping_add(w);
     d = d.rotate_left(30);
 
     u32x4(b, c, d, e)
@@ -381,46 +429,32 @@ impl Sha1State {
         let mut words = [0u32; 16];
         for i in 0..16 {
             let off = i * 4;
-            words[i] = (block[off + 3] as u32) | ((block[off + 2] as u32) << 8) |
-                       ((block[off + 1] as u32) << 16) |
-                       ((block[off] as u32) << 24);
+            words[i] = (block[off + 3] as u32)
+                | ((block[off + 2] as u32) << 8)
+                | ((block[off + 1] as u32) << 16)
+                | ((block[off] as u32) << 24);
         }
         macro_rules! schedule {
-            ($v0:expr, $v1:expr, $v2:expr, $v3:expr) => (
+            ($v0:expr, $v1:expr, $v2:expr, $v3:expr) => {
                 sha1msg2(sha1msg1($v0, $v1) ^ $v2, $v3)
-            )
+            };
         }
 
         macro_rules! rounds4 {
-            ($h0:ident, $h1:ident, $wk:expr, $i:expr) => (
+            ($h0:ident, $h1:ident, $wk:expr, $i:expr) => {
                 sha1_digest_round_x4($h0, sha1_first_half($h1, $wk), $i)
-            )
+            };
         }
 
         // Rounds 0..20
-        let mut h0 = u32x4(self.state[0],
-                           self.state[1],
-                           self.state[2],
-                           self.state[3]);
-        let mut w0 = u32x4(words[0],
-                           words[1],
-                           words[2],
-                           words[3]);
+        let mut h0 = u32x4(self.state[0], self.state[1], self.state[2], self.state[3]);
+        let mut w0 = u32x4(words[0], words[1], words[2], words[3]);
         let mut h1 = sha1_digest_round_x4(h0, sha1_first_add(self.state[4], w0), 0);
-        let mut w1 = u32x4(words[4],
-                           words[5],
-                           words[6],
-                           words[7]);
+        let mut w1 = u32x4(words[4], words[5], words[6], words[7]);
         h0 = rounds4!(h1, h0, w1, 0);
-        let mut w2 = u32x4(words[8],
-                           words[9],
-                           words[10],
-                           words[11]);
+        let mut w2 = u32x4(words[8], words[9], words[10], words[11]);
         h1 = rounds4!(h0, h1, w2, 0);
-        let mut w3 = u32x4(words[12],
-                           words[13],
-                           words[14],
-                           words[15]);
+        let mut w3 = u32x4(words[12], words[13], words[14], words[15]);
         h0 = rounds4!(h1, h0, w3, 0);
         let mut w4 = schedule!(w0, w1, w2, w3);
         h1 = rounds4!(h0, h1, w4, 0);
@@ -515,7 +549,7 @@ impl fmt::Display for DigestParseError {
     }
 }
 
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 impl std::error::Error for DigestParseError {
     fn description(&self) -> &str {
         "not a valid sha1 hash"
@@ -531,8 +565,9 @@ impl str::FromStr for Digest {
         }
         let mut rv: Digest = Default::default();
         for idx in 0..5 {
-            rv.data.state[idx] = try!(u32::from_str_radix(&s[idx * 8..idx * 8 + 8], 16)
-                .map_err(|_| DigestParseError(())));
+            rv.data.state[idx] =
+                try!(u32::from_str_radix(&s[idx * 8..idx * 8 + 8], 16)
+                    .map_err(|_| DigestParseError(())));
         }
         Ok(rv)
     }
@@ -553,7 +588,7 @@ impl fmt::Debug for Digest {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl serde::ser::Serialize for Digest {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -573,13 +608,11 @@ impl serde::ser::Serialize for Digest {
                 c += 2;
             }
         }
-        serializer.serialize_str(unsafe {
-            str::from_utf8_unchecked(&hex_str[..])
-        })
+        serializer.serialize_str(unsafe { str::from_utf8_unchecked(&hex_str[..]) })
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<'de> serde::de::Deserialize<'de> for Digest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -598,10 +631,9 @@ impl<'de> serde::de::Deserialize<'de> for Digest {
             where
                 E: serde::de::Error,
             {
-                value
-                    .parse()
-                    .map_err(|_| serde::de::Error::invalid_value(
-                        serde::de::Unexpected::Str(value), &self))
+                value.parse().map_err(|_| {
+                    serde::de::Error::invalid_value(serde::de::Unexpected::Str(value), &self)
+                })
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 #![no_std]
 #![deny(missing_docs)]
 #![allow(deprecated)]
+#![allow(clippy::double_parens)]
+#![allow(clippy::identity_op)]
 
 #[cfg(feature = "serde")]
 extern crate serde;
@@ -46,7 +48,6 @@ extern crate std;
 use core::cmp;
 use core::fmt;
 use core::hash;
-use core::mem;
 use core::str;
 
 mod simd;
@@ -96,7 +97,7 @@ const DEFAULT_STATE: Sha1State = Sha1State {
 fn as_block(input: &[u8]) -> &[u8; 64] {
     unsafe {
         assert!(input.len() == 64);
-        let arr: &[u8; 64] = mem::transmute(input.as_ptr());
+        let arr: &[u8; 64] = &*(input.as_ptr() as *const [u8; 64]);
         arr
     }
 }
@@ -430,9 +431,9 @@ fn sha1rnds4m(abcd: u32x4, msg: u32x4) -> u32x4 {
 impl Sha1State {
     fn process(&mut self, block: &[u8; 64]) {
         let mut words = [0u32; 16];
-        for i in 0..16 {
+        for (i, word) in words.iter_mut().enumerate() {
             let off = i * 4;
-            words[i] = (block[off + 3] as u32)
+            *word = (block[off + 3] as u32)
                 | ((block[off + 2] as u32) << 8)
                 | ((block[off + 1] as u32) << 16)
                 | ((block[off] as u32) << 24);
@@ -644,7 +645,7 @@ impl<'de> serde::de::Deserialize<'de> for Digest {
     }
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 #[cfg(test)]
 mod tests {
     extern crate std;
@@ -767,7 +768,7 @@ mod tests {
     }
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 #[cfg(all(test, feature="serde"))]
 mod serde_tests {
     extern crate std;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! ## Example
 //!
 //! ```rust
-//! # extern crate sha1_smol;
 //! # fn main() {
 //!
 //! let mut m = sha1_smol::Sha1::new();
@@ -24,7 +23,6 @@
 //! it once you can also use shortcuts (requires std):
 //!
 //! ```
-//! # extern crate sha1_smol;
 //! # trait X { fn hexdigest(&self) -> &'static str { "2ef7bde608ce5404e97d5f042f95f89f1c232871" }}
 //! # impl X for sha1_smol::Sha1 {}
 //! # fn main() {
@@ -39,19 +37,16 @@
 #![allow(clippy::double_parens)]
 #![allow(clippy::identity_op)]
 
-#[cfg(feature = "serde")]
-extern crate serde;
-
-#[cfg(feature = "std")]
-extern crate std;
-
 use core::cmp;
 use core::fmt;
 use core::hash;
 use core::str;
 
 mod simd;
-use simd::*;
+use crate::simd::*;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 /// The length of a SHA1 digest in bytes
 pub const DIGEST_LENGTH: usize = 20;
@@ -570,7 +565,7 @@ impl str::FromStr for Digest {
         let mut rv: Digest = Default::default();
         for idx in 0..5 {
             rv.data.state[idx] =
-                try!(u32::from_str_radix(&s[idx * 8..idx * 8 + 8], 16)
+                r#try!(u32::from_str_radix(&s[idx * 8..idx * 8 + 8], 16)
                     .map_err(|_| DigestParseError(())));
         }
         Ok(rv)
@@ -580,7 +575,7 @@ impl str::FromStr for Digest {
 impl fmt::Display for Digest {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for i in self.data.state.iter() {
-            try!(write!(f, "{:08x}", i));
+            r#try!(write!(f, "{:08x}", i));
         }
         Ok(())
     }
@@ -654,7 +649,7 @@ mod tests {
 
     use self::std::prelude::v1::*;
 
-    use Sha1;
+    use crate::Sha1;
 
     #[test]
     fn test_simple() {
@@ -758,7 +753,7 @@ mod tests {
     #[test]
     #[cfg(feature="std")]
     fn test_parse() {
-        use Digest;
+        use crate::Digest;
         use std::error::Error;
         let y: Digest = "2ef7bde608ce5404e97d5f042f95f89f1c232871".parse().unwrap();
         assert_eq!(y.to_string(), "2ef7bde608ce5404e97d5f042f95f89f1c232871");
@@ -776,7 +771,7 @@ mod serde_tests {
 
     use self::std::prelude::v1::*;
 
-    use {Sha1, Digest};
+    use crate::{Sha1, Digest};
 
     #[test]
     fn test_to_json() {

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -25,7 +25,6 @@
 // IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-
 pub use self::fake::*;
 
 pub trait SimdExt {
@@ -57,7 +56,8 @@ mod fake {
                 self.0.wrapping_add(rhs.0),
                 self.1.wrapping_add(rhs.1),
                 self.2.wrapping_add(rhs.2),
-                self.3.wrapping_add(rhs.3))
+                self.3.wrapping_add(rhs.3),
+            )
         }
     }
 
@@ -69,7 +69,8 @@ mod fake {
                 self.0.wrapping_sub(rhs.0),
                 self.1.wrapping_sub(rhs.1),
                 self.2.wrapping_sub(rhs.2),
-                self.3.wrapping_sub(rhs.3))
+                self.3.wrapping_sub(rhs.3),
+            )
         }
     }
 
@@ -77,7 +78,12 @@ mod fake {
         type Output = u32x4;
 
         fn bitand(self, rhs: u32x4) -> u32x4 {
-            u32x4(self.0 & rhs.0, self.1 & rhs.1, self.2 & rhs.2, self.3 & rhs.3)
+            u32x4(
+                self.0 & rhs.0,
+                self.1 & rhs.1,
+                self.2 & rhs.2,
+                self.3 & rhs.3,
+            )
         }
     }
 
@@ -85,7 +91,12 @@ mod fake {
         type Output = u32x4;
 
         fn bitor(self, rhs: u32x4) -> u32x4 {
-            u32x4(self.0 | rhs.0, self.1 | rhs.1, self.2 | rhs.2, self.3 | rhs.3)
+            u32x4(
+                self.0 | rhs.0,
+                self.1 | rhs.1,
+                self.2 | rhs.2,
+                self.3 | rhs.3,
+            )
         }
     }
 
@@ -93,7 +104,12 @@ mod fake {
         type Output = u32x4;
 
         fn bitxor(self, rhs: u32x4) -> u32x4 {
-            u32x4(self.0 ^ rhs.0, self.1 ^ rhs.1, self.2 ^ rhs.2, self.3 ^ rhs.3)
+            u32x4(
+                self.0 ^ rhs.0,
+                self.1 ^ rhs.1,
+                self.2 ^ rhs.2,
+                self.3 ^ rhs.3,
+            )
         }
     }
 
@@ -109,7 +125,12 @@ mod fake {
         type Output = u32x4;
 
         fn shl(self, rhs: u32x4) -> u32x4 {
-            u32x4(self.0 << rhs.0, self.1 << rhs.1, self.2 << rhs.2, self.3 << rhs.3)
+            u32x4(
+                self.0 << rhs.0,
+                self.1 << rhs.1,
+                self.2 << rhs.2,
+                self.3 << rhs.3,
+            )
         }
     }
 
@@ -125,7 +146,12 @@ mod fake {
         type Output = u32x4;
 
         fn shr(self, rhs: u32x4) -> u32x4 {
-            u32x4(self.0 >> rhs.0, self.1 >> rhs.1, self.2 >> rhs.2, self.3 >> rhs.3)
+            u32x4(
+                self.0 >> rhs.0,
+                self.1 >> rhs.1,
+                self.2 >> rhs.2,
+                self.3 >> rhs.3,
+            )
         }
     }
 


### PR DESCRIPTION
This renames the crate to `sha1-smol` and modernizes it to 2018. This raises the minimal rustc version to 1.31.0. This also adds CI.

Refs #38.